### PR TITLE
Fix inputText with interval not waiting to finish typing

### DIFF
--- a/src/main/java/com/musala/atmosphere/client/entity/ImeEntity.java
+++ b/src/main/java/com/musala/atmosphere/client/entity/ImeEntity.java
@@ -49,6 +49,8 @@ public class ImeEntity {
 
         communicator.sendAction(RoutingAction.SEND_BROADCAST, intent);
 
+        waitForTaskCompletion(text.length() * interval);
+
         return communicator.getLastException() == null;
     }
 
@@ -110,5 +112,13 @@ public class ImeEntity {
         communicator.sendAction(RoutingAction.SEND_BROADCAST, intent);
 
         return communicator.getLastException() == null;
+    }
+
+    private void waitForTaskCompletion(long timeoutInMs) {
+        try {
+            Thread.sleep(timeoutInMs);
+        } catch (InterruptedException e) {
+            // Nothing to do here
+        }
     }
 }


### PR DESCRIPTION
Add timeout after sending the inputText with interval task, so it could finish successfully before moving on to the next method in the test. Network latency issues would be reduced to minimum when the entities are migrated to the Agent.