### PR TITLE
Remove dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,12 +21,8 @@ apply plugin: 'maven-publish'
 dependencies {
     compile 'com.musala.atmosphere:atmosphere-client-server-lib:0.+'
     compile 'com.musala.atmosphere:atmosphere-bitmap-comparison:0.+'
-    compile 'com.google.guava:guava:18.0'
-    compile 'org.javassist:javassist:3.18.2-GA'
-    compile 'org.jsoup:jsoup:1.7.2'
-    compile 'org.reflections:reflections:0.9.10'
-    compile 'org.testng:testng:6.9.13.8'
 
+    compile 'org.testng:testng:6.9.13.8'
     compile 'org.glassfish.tyrus:tyrus-client:1.13.1'
     compile 'org.glassfish.tyrus:tyrus-container-grizzly-client:1.13.1'
 

--- a/src/main/java/com/musala/atmosphere/client/PickerHelper.java
+++ b/src/main/java/com/musala/atmosphere/client/PickerHelper.java
@@ -42,7 +42,7 @@ public class PickerHelper {
             UiElementFetchingException {
         UiElement numberPickerField = getNumberPickerField(index);
         UiElementPropertiesContainer numberPickerFieldElementProperties = numberPickerField.getProperties();
-        screen.updateScreen();
+
         return numberPickerFieldElementProperties.getText();
     }
 
@@ -67,8 +67,6 @@ public class PickerHelper {
         if (!numberPickerField.inputText(text)) {
             return false;
         }
-
-        screen.updateScreen();
 
         return true;
     }
@@ -122,8 +120,6 @@ public class PickerHelper {
 
         // We click on the picker to make it visible.
         numberPicker.tap();
-
-        screen.updateScreen();
 
         UiElement numberPickerClicked = screen.getElement(numberPickerSelector);
 

--- a/src/main/java/com/musala/atmosphere/client/Screen.java
+++ b/src/main/java/com/musala/atmosphere/client/Screen.java
@@ -1,21 +1,9 @@
 package com.musala.atmosphere.client;
 
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.PrintStream;
-import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-
 import org.apache.log4j.Logger;
-import org.jsoup.Jsoup;
-import org.w3c.dom.Document;
-import org.xml.sax.InputSource;
-import org.xml.sax.SAXException;
 
 import com.musala.atmosphere.client.exceptions.ActionFailedException;
 import com.musala.atmosphere.client.exceptions.InvalidCssQueryException;
@@ -49,51 +37,13 @@ public class Screen {
 
     private static final String MULTIPLE_PICKERS_AVAILABLE_MESSAGE = "More than one %s picker is currently available on the screen.";
 
-    private String screenXml;
-
-    private Document xPathDomDocument;
-
-    private org.jsoup.nodes.Document jSoupDocument;
-
     private final DeviceCommunicator communicator;
 
     private final AccessibilityElementUtils elementUtils;
 
-    @Deprecated
-
-    Screen(String uiHierarchyXml,
-            DeviceCommunicator communicator) {
-        this.communicator = communicator;
-        this.elementUtils = new AccessibilityElementUtils(communicator);
-        screenXml = uiHierarchyXml;
-
-        // XPath DOM Document building
-        DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-        documentBuilderFactory.setNamespaceAware(true);
-        try {
-            DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
-            xPathDomDocument = documentBuilder.parse(new InputSource(new StringReader(screenXml)));
-        } catch (ParserConfigurationException | SAXException | IOException e) {
-            String message = "XPath XML to DOM Document parsing failed.";
-            LOGGER.warn(message, e);
-        }
-
-        // JSoup Document building
-        jSoupDocument = Jsoup.parse(screenXml);
-    }
-
     Screen(DeviceCommunicator communicator) {
         this.communicator = communicator;
         this.elementUtils = new AccessibilityElementUtils(communicator);
-    }
-
-    /**
-     * Updates the current {@link Screen} instance to contain the newest possible device screen information. Equivalent
-     * to reinvoking the {@link Device#getActiveScreen()} method.
-     */
-    @Deprecated
-    public void updateScreen() {
-        // This will be removed.
     }
 
     /**
@@ -122,23 +72,6 @@ public class Screen {
      */
     public List<UiElement> getElements(UiElementSelector selector) throws UiElementFetchingException {
         return getElements(selector, true);
-    }
-
-    /**
-     * Saves the underlying device UI XML into a file.
-     *
-     * @param path
-     *        - full path to file in which the UI XML should be saved.
-     * @throws FileNotFoundException
-     *         when the passed argument does not denote already existing and writable file or such can not be created
-     *         for some reason
-     */
-    @Deprecated
-    public void exportToXml(String path) throws FileNotFoundException {
-        // FIXME this implementation is not valid anymore. UiAutomator should be used here.
-        PrintStream export = new PrintStream(path);
-        export.print(screenXml);
-        export.close();
     }
 
     /**
@@ -348,7 +281,6 @@ public class Screen {
         boolean isElementPresent = waitForElementExists(selector, waitTimeout);
 
         if (isElementPresent) {
-            updateScreen();
             UiElement selectedElement = getElement(selector);
             return selectedElement;
         } else {

--- a/src/main/java/com/musala/atmosphere/client/uiutils/CssToXPathConverter.java
+++ b/src/main/java/com/musala/atmosphere/client/uiutils/CssToXPathConverter.java
@@ -3,12 +3,13 @@ package com.musala.atmosphere.client.uiutils;
 import static com.musala.atmosphere.client.uiutils.XPathAttribute.isAttributeStringOfTheEnumeration;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.apache.log4j.Logger;
 
-import com.google.common.collect.ImmutableMap;
 import com.musala.atmosphere.client.exceptions.InvalidCssQueryException;
 
 /**
@@ -42,10 +43,16 @@ public class CssToXPathConverter {
 
     private static final Logger LOGGER = Logger.getLogger(CssToXPathConverter.class);
 
-    private static final Map<String, String> cssToXPathAttributeConversionMap = ImmutableMap.of("class", "className",
-                                                                                                "content-desc", "contentDesc",
-                                                                                                "long-clickable", "longClickable",
-                                                                                                "resource-id", "resourceId");
+    private static final Map<String, String> cssToXPathAttributeConversionMap;
+
+    static {
+        Map<String, String> aMap = new HashMap<String, String>();
+        aMap.put("class", "className");
+        aMap.put("content-desc", "contentDesc");
+        aMap.put("long-clickable", "longClickable");
+        aMap.put("resource-id", "resourceId");
+        cssToXPathAttributeConversionMap = Collections.unmodifiableMap(aMap);
+    }
 
     /**
      * Divides the CSS Query to property selectors


### PR DESCRIPTION
Remove some `Deprecated` constructors and methods from the `Client`

As a result of removing the deprecated `Screen` constructor some `gradle` dependencies can be omitted:
*  `com.google.guava:guava:18.0`
*  `org.javassist:javassist:3.18.2-GA`
*  `org.jsoup:jsoup:1.7.2`

The `org.reflections:reflections:0.9.10` is also redundant because of  `entity-migration`

closes MusalaSoft/atmosphere-docs#104